### PR TITLE
Add and refer to changelog page

### DIFF
--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -1,0 +1,12 @@
+---
+title: Changelog
+description: Important changes to the [Aloft bucket](/browse/).
+permalink: /changelog/
+toc: true
+---
+
+## baltrad
+
+- **2025-12-09**: EUMETNET updated the list of OPERA member countries that grant access to single site radar data and data products. Cyprus, Greece, Hungary, Iceland, Ireland, Latvia, Lithuania, Malta, Romania, and Serbia have joined the agreement. Israel has left. As with all countries in the agreement, PVOL data (if available) are processed by BALTRAD to VPTS data. This is now the case for the following **19 new radars**, for most since 2025-12-09: `grand`, `hubud`, `huhar`, `hunap`, `hupog`, `husze`, `isbjo`, `iskef`, `isska`, `iesha`, `ltlau`, `ltvil`, `robar`, `robob`, `robuc`, `rocra`, `romed`, `roora`, `rotim`. See [this blog post](https://hirad.science/news/2026/aloft-new-countries/) for details.
+
+- **2026-04-13**: BALTRAD processing was down the first 8 months of 2022, resulting in a [gap of coverage](https://static-content.springer.com/esm/art%3A10.1038%2Fs41597-025-04641-5/MediaObjects/41597_2025_4641_MOESM1_ESM.pdf) for all countries between 2022-01-01 and 2022-08-20. This **2022 gap is remedied for Sweden**: we received hdf5 vp data from SMHI that is processed the same way as it would be on BALTRAD. We uploaded those data to the bucket, completing the gap and overwriting any existing data for August 2022. See [#112](https://github.com/aloftdata/data-repository/issues/112) for details.

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -35,6 +35,13 @@ The bucket contains data from 3 sources:
 <details markdown="1">
 <summary>How often are the data updated?</summary>
 `baltrad` data are updated daily. HDF5 data are typically available 24 hours after the radar collected the raw data, while daily and monthly summaries are available within 48 hours.
+
+For important updates, see the [changelog](/changelog/).
+</details>
+
+<details markdown="1">
+<summary>Are there any important updates?</summary>
+Yes, see the [changelog](/changelog/).
 </details>
 
 <details markdown="1">

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -36,11 +36,11 @@ The bucket contains data from 3 sources:
 <summary>How often are the data updated?</summary>
 `baltrad` data are updated daily. HDF5 data are typically available 24 hours after the radar collected the raw data, while daily and monthly summaries are available within 48 hours.
 
-For important updates, see the [changelog](/changelog/).
+For important changes, see the [changelog](/changelog/).
 </details>
 
 <details markdown="1">
-<summary>Are there any important updates?</summary>
+<summary>Are there any important changes?</summary>
 Yes, see the [changelog](/changelog/).
 </details>
 


### PR DESCRIPTION
We've recently had 2 important changes to the Aloft bucket (more radars + 2022 data gap filled for Sweden), with more likely coming. I think it will be useful to have an **overview** of those changes. These can inform the user and ourselves, especially when we create a new deposit on Zenodo.

I've created `changelog` page to the website. It is not linked from the navigation, but from 2 faq:

<img width="647" height="433" alt="Screenshot 2026-04-13 at 11 40 00" src="https://github.com/user-attachments/assets/6131c2b4-bd08-4a9e-92d3-c09f69a1cbbc" />

The changelog currently looks like this. Bullet points are organized by source (`baltrad`) and chronological date of change:

<img width="1986" height="1566" alt="Changelog-Aloft-04-13-2026_11_33_AM" src="https://github.com/user-attachments/assets/5ea048a3-ecd8-4bb3-ab70-055c5064055a" />

/cc @bart1 @CeciliaNilsson709 