### PR TITLE
Update VPTS CSV landing page to version 1.1

### DIFF
--- a/_data/vpts-csv-table-schema.json
+++ b/_data/vpts-csv-table-schema.json
@@ -23,13 +23,27 @@
     {
       "name": "height",
       "nameAlternatives": ["HGHT", "bin_lower"],
-      "description": "Lower bound of the altitude bin in m above sea level.",
-      "type": "integer",
+      "description": "Lower bound of the altitude bin in m, measured from `height_reference`.",
+      "type": "number",
       "example": "600",
       "constraints": {
         "required": true,
         "minimum": -200,
         "maximum": 25000
+      }
+    },
+    {
+      "name": "height_reference",
+      "description": "Reference for `height`. Height values can be in m above sea level (`\"sea\"`), ground level (`\"ground\"`) or antenna level (`\"antenna\"`).",
+      "type": "string",
+      "example": "sea",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "sea",
+          "ground",
+          "antenna"
+        ]
       }
     },
     {
@@ -228,7 +242,7 @@
     {
       "name": "radar_height",
       "description": "Height of the center of the radar antenna in m above sea level. Constant for all records from the same `radar`.",
-      "type": "integer",
+      "type": "number",
       "example": "519",
       "constraints": {
         "required": true,

--- a/_data/vpts-csv-table-schema.json
+++ b/_data/vpts-csv-table-schema.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "height_reference",
-      "description": "Reference for `height`. Height values can be in m above sea level (`\"sea\"`), ground level (`\"ground\"`) or antenna level (`\"antenna\"`).",
+      "description": "Reference for `height`. `\"sea\"` and `\"antenna\"` are used for heights defined from mean sea level and radar antenna respectively, resulting in horizontal altitude bins. `\"terrain\"` is used for heights that are calculated relative to a digital elevation model for each pixel in the volume.",
       "type": "string",
       "example": "sea",
       "constraints": {
         "required": true,
         "enum": [
           "sea",
-          "ground",
-          "antenna"
+          "antenna",
+          "terrain"
         ]
       }
     },

--- a/pages/vpts-csv.md
+++ b/pages/vpts-csv.md
@@ -37,6 +37,13 @@ The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `S
 - Data SHOULD have the same `height`s for all `datetime`s of a `radar`.
 - Fields SHOULD be organized in the order presented below.
 
+## Versions
+
+Version | Comments
+--- | ---
+[1.1](https://github.com/aloftdata/vpts-csv/releases/tag/v1.1) | `height_reference` added as a new required column. VPTS CSV 1.0 files without this column should be interpreted as `"sea"`.<br>`height` and `radar_height` type changed from integer to number.
+[1.0](https://github.com/aloftdata/vpts-csv/releases/tag/v1.0) | First release
+
 ## Fields
 
 Source: <https://github.com/aloftdata/vpts-csv/blob/main/vpts-csv-table-schema.json>

--- a/pages/vpts-csv.md
+++ b/pages/vpts-csv.md
@@ -14,11 +14,11 @@ VPTS CSV is maintained at <https://github.com/aloftdata/vpts-csv>.
 ## Example
 
 ```
-radar,datetime,height,u,v,w,ff,dd,sd_vvp,gap,eta,dens,dbz,dbz_all,n,n_dbz,n_all,n_dbz_all,rcs,sd_vvp_threshold,vcp,radar_latitude,radar_longitude,radar_height,radar_wavelength,source_file
-KBGM,2016-09-01T00:02:00Z,0,,,,,,,TRUE,,,,,0,0,0,0,11,2,,42.19972,-75.98472,519,10.6,s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06
-KBGM,2016-09-01T00:02:00Z,200,,,,,,,TRUE,,,,,0,0,0,0,11,2,,42.19972,-75.98472,519,10.6,s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06
-KBGM,2016-09-01T00:02:00Z,400,,,,,,2.81,TRUE,30.8,2.8000000000000003,1.54,3.77,326,356,22485,28416,11,2,,42.19972,-75.98472,519,10.6,s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06
-KBGM,2016-09-01T00:02:00Z,600,4.14,3.84,12.17,5.65,47.2,2.8,FALSE,46.9,4.263636363636364,3.36,0.5,9006,13442,65947,104455,11,2,,42.19972,-75.98472,519,10.6,s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06
+radar,datetime,height,height_reference,u,v,w,ff,dd,sd_vvp,gap,eta,dens,dbz,dbz_all,n,n_dbz,n_all,n_dbz_all,rcs,sd_vvp_threshold,vcp,radar_latitude,radar_longitude,radar_height,radar_wavelength,source_file
+KBGM,2016-09-01T00:02:00Z,0,sea,,,,,,,TRUE,,,,,0,0,0,0,11,2,,42.19972,-75.98472,519,10.6,s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06
+KBGM,2016-09-01T00:02:00Z,200,sea,,,,,,,TRUE,,,,,0,0,0,0,11,2,,42.19972,-75.98472,519,10.6,s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06
+KBGM,2016-09-01T00:02:00Z,400,sea,,,,,,2.81,TRUE,30.8,2.8000000000000003,1.54,3.77,326,356,22485,28416,11,2,,42.19972,-75.98472,519,10.6,s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06
+KBGM,2016-09-01T00:02:00Z,600,sea,4.14,3.84,12.17,5.65,47.2,2.8,FALSE,46.9,4.263636363636364,3.36,0.5,9006,13442,65947,104455,11,2,,42.19972,-75.98472,519,10.6,s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06
 ```
 
 ## Requirements


### PR DESCRIPTION
Add version table:

<img width="791" height="269" alt="Screenshot 2026-06-24 at 14 38 32" src="https://github.com/user-attachments/assets/16ef33d4-b47c-4555-8b87-442012e2674c" />

Update example (add `height_reference = "sea"`):

<img width="786" height="202" alt="Screenshot 2026-06-24 at 14 39 12" src="https://github.com/user-attachments/assets/3f0cd3d1-647f-42a5-ae76-67290066512c" />

Add `height_reference` field + update the definition of `height` to refer to it:

<img width="754" height="490" alt="Screenshot 2026-06-24 at 14 38 47" src="https://github.com/user-attachments/assets/4e6c0ba3-fb7b-4e8a-8a59-d05eab40b8f1" />